### PR TITLE
feat: add BulkTransferStatus

### DIFF
--- a/aozorabank/const.go
+++ b/aozorabank/const.go
@@ -46,6 +46,29 @@ const (
 	TransferStatusFailed                  TransferStatus = 40
 )
 
+type BulkTransferStatus int
+
+const (
+	BulkTransferStatusApplying             BulkTransferStatus = 2
+	BulkTransferStatusReturned             BulkTransferStatus = 3
+	BulkTransferStatusDismiss              BulkTransferStatus = 4
+	BulkTransferStatusExpired              BulkTransferStatus = 5
+	BulkTransferStatusApprovalCancelled    BulkTransferStatus = 8
+	BulkTransferStatusInReserve            BulkTransferStatus = 11
+	BulkTransferStatusInProgress           BulkTransferStatus = 12
+	BulkTransferStatusRetrying             BulkTransferStatus = 13
+	BulkTransferStatusCompleted            BulkTransferStatus = 20
+	BulkTransferStatusPartiallyUnavailable BulkTransferStatus = 30
+	BulkTransferStatusFailed               BulkTransferStatus = 40
+)
+
+type BulkTransferItemStatus int
+
+const (
+	BulkTransferItemStatusSuccess BulkTransferItemStatus = 1
+	BulkTransferItemStatusFailure BulkTransferItemStatus = 2
+)
+
 type RequestTransferClass int
 
 const (

--- a/aozorabank/transfer.go
+++ b/aozorabank/transfer.go
@@ -93,6 +93,7 @@ type (
 	}
 
 	transferInfo struct {
+		ItemID                  string                    `json:"itemId"`
 		TransferAmount          string                    `json:"transferAmount"`
 		EdiInfo                 string                    `json:"ediInfo"`
 		BeneficiaryBankCode     string                    `json:"beneficiaryBankCode"`
@@ -115,10 +116,10 @@ type (
 	}
 
 	unableDetailInfo struct {
-		TransferDetailStatus string `json:"transferDetailStatus"`
-		RefundStatus         string `json:"refundStatus"`
-		IsRepayment          bool   `json:"isRepayment"`
-		RepaymentDate        string `json:"repaymentDate"`
+		TransferDetailStatus BulkTransferItemStatus `json:"transferDetailStatus"`
+		RefundStatus         string                 `json:"refundStatus"`
+		IsRepayment          bool                   `json:"isRepayment"`
+		RepaymentDate        string                 `json:"repaymentDate"`
 	}
 )
 
@@ -262,7 +263,7 @@ type (
 	}
 
 	bulkTransferDetail struct {
-		TransferStatus     TransferStatus          `json:"transferStatus,string"`
+		TransferStatus     BulkTransferStatus      `json:"transferStatus,string"`
 		TransferStatusName string                  `json:"transferStatusName"`
 		TransferTypeName   string                  `json:"transferTypeName"`
 		IsFeeFreeUse       bool                    `json:"isFeeFreeUse"`
@@ -281,7 +282,7 @@ type (
 		AccountID              string          `json:"accountID"`
 		RemitterName           string          `json:"remitterName"`
 		TransferDesignatedDate string          `json:"transferDesignatedDate"`
-		TotalCount             string          `json:"totalCount,string"`
+		TotalCount             string          `json:"totalCount"`
 		TotalAmount            string          `json:"totalAmount"`
 		TransferInfos          []*transferInfo `json:"bulkTransferInfos"`
 	}


### PR DESCRIPTION
## Proposed Changes
- 通常振込と総合振込では振込ステータス(transferStatus)が微妙に異なっているため、総合振込用のステータスを別途定義
- 明細ごとのステータス(transferDetailStatus)をBulkTransferItemStatusとして定義
- transferInfo に itemID を追加

API仕様書 https://gmo-aozora.com/business/service/pdf/api-spec-corporate.pdf
